### PR TITLE
Create embeddings + Vector Store

### DIFF
--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -81,11 +81,11 @@ clean_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.{table_name}")
 
 # COMMAND ----------
 
-from pyspark.sql import functions as F
-from pyspark.sql import types as T
+from pyspark.sql.functions import udf
+from pyspark.sql.types import ArrayType, StringType
 
 # Simple Chunking
-@udf(returnType=T.ArrayType(T.StringType()))
+@udf(returnType=ArrayType(StringType()))
 def chunk_text(text, chunk_size=1000):
     if text is None:
         return []

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -15,7 +15,8 @@
 
 import json
 catalog = "frantzpaul_tech"
-schema = "wnba_rag"
+schema = "wnba_chat"
+table_name = "news_articles"
 
 # COMMAND ----------
 
@@ -24,18 +25,21 @@ schema = "wnba_rag"
 
 # COMMAND ----------
 
-path = "./wnba_news.json"
-with open(path, "r") as f:
-  data = json.load(f)
+# path = "./wnba_news.json"
+# with open(path, "r") as f:
+#   data = json.load(f)
+
+# # create dataframe
+# df = spark.createDataFrame(data)
+# display(df)
+
+# # save to table
+# # spark.createDataFrame(data).write.mode("overwrite").saveAsTable("wnba_news")
 
 # COMMAND ----------
 
-# create dataframe
-df = spark.createDataFrame(data)
-display(df)
-
-# save to table
-# spark.createDataFrame(data).write.mode("overwrite").saveAsTable("wnba_news")
+data = spark.read.table(f"{catalog}.{schema}.{table_name}")
+display(data)
 
 # COMMAND ----------
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -84,14 +84,15 @@ clean_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.{table_name}")
 from pyspark.sql.functions import udf
 from pyspark.sql.types import ArrayType, StringType
 
-# Simple Chunking
+CHUNK_SIZE = 1000
+
 @udf(returnType=ArrayType(StringType()))
-def chunk_text(text, chunk_size=1000):
+def chunk_text(text0):
     if text is None:
         return []
     
     words = text.split()
-    chunks = [" ".join(words[i:i+chunk_size]) for i in range(0, len(words), chunk_size)]
+    chunks = [" ".join(words[i:i+chunk_size]) for i in range(0, len(words), CHUNK_SIZE)]
     return chunks
 
 # COMMAND ----------

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -54,6 +54,11 @@ display(clean_df)
 # COMMAND ----------
 
 # MAGIC %md
+# MAGIC # Preprocess Data
+
+# COMMAND ----------
+
+# MAGIC %md
 # MAGIC # Save to Delta Table
 
 # COMMAND ----------

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -38,8 +38,8 @@ table_name = "news_articles"
 
 # COMMAND ----------
 
-data = spark.read.table(f"{catalog}.{schema}.{table_name}")
-display(data)
+df = spark.read.table(f"{catalog}.{schema}.{table_name}")
+display(df)
 
 # COMMAND ----------
 
@@ -52,7 +52,7 @@ display(data)
 
 from pyspark.sql.functions import regexp_replace
 # remove newlines in text column
-clean_df = df.withColumn("text", regexp_replace("text", "\n", " "))
+clean_df = df.withColumn("text_clean", regexp_replace("text", "\n", " "))
 display(clean_df)
 
 # COMMAND ----------

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -5,14 +5,6 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install pinecone
-
-# COMMAND ----------
-
-# MAGIC %restart_python
-
-# COMMAND ----------
-
 import json
 catalog = "frantzpaul_tech"
 schema = "wnba_chat"
@@ -114,9 +106,27 @@ display(chunked_df)
 
 # COMMAND ----------
 
+from pyspark.sql.functions import explode, col, monotonically_increasing_id
+
+chunks_df = (
+    chunked_df
+    .withColumn("chunk_text", explode(col("chunked_text")))
+    .withColumn("chunk_id", monotonically_increasing_id())
+    .select(
+        "chunk_id",
+        "chunk_text",
+        "title",
+        "source",
+        "url",
+        "date"
+    )
+)
+
+# COMMAND ----------
+
 # MAGIC %md
 # MAGIC # Save Data to Delta Table
 
 # COMMAND ----------
 
-chunked_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.news_articles_chunked")
+chunks_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.news_articles_chunked")

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -16,7 +16,7 @@
 import json
 catalog = "frantzpaul_tech"
 schema = "wnba_chat"
-table_name = "news_articles"
+table_name = "news_articles_bronze"
 
 # COMMAND ----------
 
@@ -25,16 +25,16 @@ table_name = "news_articles"
 
 # COMMAND ----------
 
-# path = "./wnba_news.json"
-# with open(path, "r") as f:
-#   data = json.load(f)
+path = "./wnba_news.json"
+with open(path, "r") as f:
+  data = json.load(f)
 
-# # create dataframe
-# df = spark.createDataFrame(data)
-# display(df)
+# create dataframe
+df = spark.createDataFrame(data)
+display(df)
 
-# # save to table
-# # spark.createDataFrame(data).write.mode("overwrite").saveAsTable("wnba_news")
+# save to table
+spark.createDataFrame(data).write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.{table_name}")
 
 # COMMAND ----------
 
@@ -71,6 +71,7 @@ display(clean_df)
 
 catalog = "frantzpaul_tech"
 schema = "wnba_chat"
+table_name = "news_articles_clean"
 
 # COMMAND ----------
 
@@ -78,7 +79,8 @@ spark.sql(f"create database if not exists {catalog}.{schema}")
 
 # COMMAND ----------
 
-clean_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.news_articles")
+clean_df = clean_df.drop("text")
+clean_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.{table_name}")
 
 # COMMAND ----------
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -46,7 +46,14 @@ display(df)
 # MAGIC %md
 # MAGIC # Clean Data
 # MAGIC
+# MAGIC - Drop row with empty text column
 # MAGIC - Remove newlines in text column
+
+# COMMAND ----------
+
+# drop row with empty text column
+df = df.filter(df.text != "")
+display(df)
 
 # COMMAND ----------
 
@@ -77,9 +84,13 @@ def chunk_text(text, chunk_size=1000):
 
 # COMMAND ----------
 
+from pyspark.sql.types import StringType
 # Apply UDF
-# chunked_df = clean_df.withColumn("chunked_text", chunk_text(F.col("text"), 1000))
-# display(chunked_df)
+chunked_df = clean_df.withColumn(
+    "chunked_text",
+    chunk_text(F.col("text_clean"))
+)
+display(chunked_df)
 
 # COMMAND ----------
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -65,6 +65,24 @@ display(clean_df)
 # COMMAND ----------
 
 # MAGIC %md
+# MAGIC # Save to Delta Table
+
+# COMMAND ----------
+
+catalog = "frantzpaul_tech"
+schema = "wnba_chat"
+
+# COMMAND ----------
+
+spark.sql(f"create database if not exists {catalog}.{schema}")
+
+# COMMAND ----------
+
+clean_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.news_articles")
+
+# COMMAND ----------
+
+# MAGIC %md
 # MAGIC # Preprocess Data
 
 # COMMAND ----------
@@ -95,17 +113,4 @@ display(chunked_df)
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC # Save to Delta Table
-
-# COMMAND ----------
-
-catalog = "frantzpaul_tech"
-schema = "wnba_chat"
-
-# COMMAND ----------
-
-spark.sql(f"create database if not exists {catalog}.{schema}")
-
-# COMMAND ----------
-
-clean_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.news_articles")
+# MAGIC

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -61,16 +61,11 @@ display(clean_df)
 
 # COMMAND ----------
 
-catalog = "frantzpaul_tech"
-schema = "wnba_chat"
-table_name = "news_articles_clean"
-
-# COMMAND ----------
-
 spark.sql(f"create database if not exists {catalog}.{schema}")
 
 # COMMAND ----------
 
+table_name = "news_articles_clean"
 clean_df = clean_df.drop("text")
 clean_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.{table_name}")
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -1,4 +1,10 @@
 # Databricks notebook source
+# MAGIC %md
+# MAGIC # About
+# MAGIC This notebook imports the json data and cleanss up the data. It also saves the clean dataset as a delta table on Databricks.
+
+# COMMAND ----------
+
 # MAGIC %pip install pinecone
 
 # COMMAND ----------
@@ -42,8 +48,26 @@ display(df)
 
 from pyspark.sql.functions import regexp_replace
 # remove newlines in text column
-df = df.withColumn("text", regexp_replace("text", "\n", " "))
-display(df)
+clean_df = df.withColumn("text", regexp_replace("text", "\n", " "))
+display(clean_df)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC # Save to Delta Table
+
+# COMMAND ----------
+
+catalog = "frantzpaul_tech"
+schema = "wnba_chat"
+
+# COMMAND ----------
+
+spark.sql(f"create database if not exists {catalog}.{schema}")
+
+# COMMAND ----------
+
+clean_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.news_articles")
 
 # COMMAND ----------
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -102,7 +102,6 @@ chunked_df = clean_df.withColumn(
     "chunked_text",
     chunk_text(F.col("text_clean"))
 )
-display(chunked_df)
 
 # COMMAND ----------
 
@@ -121,6 +120,10 @@ chunks_df = (
         "date"
     )
 )
+
+# COMMAND ----------
+
+display(chunks_df)
 
 # COMMAND ----------
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -115,4 +115,8 @@ display(chunked_df)
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC
+# MAGIC # Save Data to Delta Table
+
+# COMMAND ----------
+
+chunked_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.news_articles_chunked")

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -62,12 +62,20 @@ from pyspark.sql import functions as F
 from pyspark.sql import types as T
 
 # Simple Chunking
+@udf(returnType=T.ArrayType(T.StringType()))
 def chunk_text(text, chunk_size=1000):
     if text is None:
         return []
     
     words = text.split()
     chunks = [" ".join(words[i:i+chunk_size]) for i in range(0, len(words), chunk_size)]
+    return chunks
+
+# COMMAND ----------
+
+# Apply UDF
+# chunked_df = clean_df.withColumn("chunked_text", chunk_text(F.col("text"), 1000))
+# display(chunked_df)
 
 # COMMAND ----------
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -1,0 +1,28 @@
+# Databricks notebook source
+import json
+catalog = "frantzpaul_tech"
+schema = "wnba_rag"
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC # Import Data
+
+# COMMAND ----------
+
+path = "./wnba_news.json"
+with open(path, "r") as f:
+  data = json.load(f)
+
+# COMMAND ----------
+
+# create dataframe
+df = spark.createDataFrame(data)
+display(df)
+
+# save to table
+# spark.createDataFrame(data).write.mode("overwrite").saveAsTable("wnba_news")
+
+# COMMAND ----------
+
+

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -1,4 +1,12 @@
 # Databricks notebook source
+# MAGIC %pip install pinecone
+
+# COMMAND ----------
+
+# MAGIC %restart_python
+
+# COMMAND ----------
+
 import json
 catalog = "frantzpaul_tech"
 schema = "wnba_rag"
@@ -22,6 +30,20 @@ display(df)
 
 # save to table
 # spark.createDataFrame(data).write.mode("overwrite").saveAsTable("wnba_news")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC # Clean Data
+# MAGIC
+# MAGIC - Remove newlines in text column
+
+# COMMAND ----------
+
+from pyspark.sql.functions import regexp_replace
+# remove newlines in text column
+df = df.withColumn("text", regexp_replace("text", "\n", " "))
+display(df)
 
 # COMMAND ----------
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -92,7 +92,6 @@ def chunk_text(text0):
 
 # COMMAND ----------
 
-from pyspark.sql.types import StringType
 # Apply UDF
 chunked_df = clean_df.withColumn(
     "chunked_text",

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -58,6 +58,19 @@ display(clean_df)
 
 # COMMAND ----------
 
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+
+# Simple Chunking
+def chunk_text(text, chunk_size=1000):
+    if text is None:
+        return []
+    
+    words = text.split()
+    chunks = [" ".join(words[i:i+chunk_size]) for i in range(0, len(words), chunk_size)]
+
+# COMMAND ----------
+
 # MAGIC %md
 # MAGIC # Save to Delta Table
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -1,7 +1,12 @@
 # Databricks notebook source
 # MAGIC %md
 # MAGIC # About
-# MAGIC This notebook imports the json data and cleanss up the data. It also saves the clean dataset as a delta table on Databricks.
+# MAGIC This notebook imports the json data and cleans up the data. Afterwards, it preprocesses the data to chunk our data into chunks. It also saves the clean dataset as a delta table on Databricks.
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC # Define Variables
 
 # COMMAND ----------
 

--- a/data/data_prep.py
+++ b/data/data_prep.py
@@ -68,7 +68,3 @@ spark.sql(f"create database if not exists {catalog}.{schema}")
 # COMMAND ----------
 
 clean_df.write.mode("overwrite").saveAsTable(f"{catalog}.{schema}.news_articles")
-
-# COMMAND ----------
-
-

--- a/data/pinecone_vector_creation.py
+++ b/data/pinecone_vector_creation.py
@@ -9,7 +9,7 @@ dbutils.library.restartPython()
 
 catalog = "frantzpaul_tech"
 schema = "wnba_chat"
-table_name = "news_articles"
+table_name = "news_articles_chunked"
 
 # COMMAND ----------
 
@@ -75,3 +75,28 @@ response = client.embeddings.create(
   model="text-embedding-ada-002",
   input="Hello world"
 )
+
+# COMMAND ----------
+
+def create_embeddings(df):
+    vectors_to_upsert = []
+
+    for idx, row in df.iterrows():
+        for chunk_idx, chunk in enumerate(row['chunked_text']):
+            vector_id = f"{idx}_{chunk_idx}"
+
+            # Generate embedding
+            embedding = None
+
+            metadata = {
+                "date": row['date'],
+                "source": row['source'],
+                "title": row['title']
+            }
+
+            vectors_to_upsert.append((vector_id, embedding, metadata))
+
+    if vectors_to_upsert:
+        index.upsert(vectors=vectors_to_upsert)
+
+    return vectors_to_upsert

--- a/data/pinecone_vector_creation.py
+++ b/data/pinecone_vector_creation.py
@@ -1,10 +1,14 @@
 # Databricks notebook source
 catalog = "frantzpaul_tech"
 schema = "wnba_chat"
-table_name = "new_articles"
+table_name = "news_articles"
 
 # COMMAND ----------
 
 data = spark.read.table(f"{catalog}.{schema}.{table_name}")
 display(data)
 data.count()
+
+# COMMAND ----------
+
+

--- a/data/pinecone_vector_creation.py
+++ b/data/pinecone_vector_creation.py
@@ -1,5 +1,5 @@
 # Databricks notebook source
-# MAGIC %pip install pinecone
+# MAGIC %pip install pinecone openai
 
 # COMMAND ----------
 
@@ -25,7 +25,7 @@ data.count()
 # COMMAND ----------
 
 def get_pinecone_api_key():
-  api_key = ""
+  api_key = dbutils.secrets.get(scope="wnba_chat_app", key="pinecone")
   return api_key
 
 PINECONE_KEY = get_pinecone_api_key()
@@ -45,7 +45,7 @@ pc = Pinecone(
 
 # COMMAND ----------
 
-index_name = "wnba_chat_pinecone_rag"
+index_name = "wnba-chat-pinecone-rag"
 from pinecone import ServerlessSpec
 
 if not pc.has_index(index_name):
@@ -65,3 +65,13 @@ index = pc.Index(name=index_name)
 
 # View index stats
 index.describe_index_stats()
+
+# COMMAND ----------
+
+from openai import OpenAI
+client = OpenAI()
+
+response = client.embeddings.create(
+  model="text-embedding-ada-002",
+  input="Hello world"
+)

--- a/data/pinecone_vector_creation.py
+++ b/data/pinecone_vector_creation.py
@@ -1,4 +1,12 @@
 # Databricks notebook source
+# MAGIC %pip install pinecone
+
+# COMMAND ----------
+
+dbutils.library.restartPython()
+
+# COMMAND ----------
+
 catalog = "frantzpaul_tech"
 schema = "wnba_chat"
 table_name = "news_articles"
@@ -21,6 +29,11 @@ def get_pinecone_api_key():
   return api_key
 
 PINECONE_KEY = get_pinecone_api_key()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC # Setting up  Pinecone Index
 
 # COMMAND ----------
 

--- a/data/pinecone_vector_creation.py
+++ b/data/pinecone_vector_creation.py
@@ -37,4 +37,31 @@ PINECONE_KEY = get_pinecone_api_key()
 
 # COMMAND ----------
 
+from pinecone import Pinecone
 
+pc = Pinecone(
+    api_key=PINECONE_KEY
+)
+
+# COMMAND ----------
+
+index_name = "wnba_chat_pinecone_rag"
+from pinecone import ServerlessSpec
+
+if not pc.has_index(index_name):
+  pc.create_index(
+      index_name, 
+      dimension=1536,
+      metric="cosine",
+       # parameters for the free tier index
+        spec=ServerlessSpec(
+            cloud="aws",
+            region="us-east-1"
+        )
+  )
+
+# Initialize index client
+index = pc.Index(name=index_name)
+
+# View index stats
+index.describe_index_stats()

--- a/data/pinecone_vector_creation.py
+++ b/data/pinecone_vector_creation.py
@@ -1,4 +1,10 @@
 # Databricks notebook source
+# MAGIC %md
+# MAGIC # About
+# MAGIC This notebook sets up the vector embedding process using OpenAI for embeddings creation and 
+
+# COMMAND ----------
+
 # MAGIC %pip install pinecone openai
 
 # COMMAND ----------
@@ -119,3 +125,7 @@ results = index.query(
     top_k=5,
     include_metadata=True
 )
+
+# COMMAND ----------
+
+display(results)

--- a/data/pinecone_vector_creation.py
+++ b/data/pinecone_vector_creation.py
@@ -1,0 +1,10 @@
+# Databricks notebook source
+catalog = "frantzpaul_tech"
+schema = "wnba_chat"
+table_name = "new_articles"
+
+# COMMAND ----------
+
+data = spark.read.table(f"{catalog}.{schema}.{table_name}")
+display(data)
+data.count()

--- a/data/pinecone_vector_creation.py
+++ b/data/pinecone_vector_creation.py
@@ -11,4 +11,17 @@ data.count()
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC # Setting up Pinecone
+
+# COMMAND ----------
+
+def get_pinecone_api_key():
+  api_key = ""
+  return api_key
+
+PINECONE_KEY = get_pinecone_api_key()
+
+# COMMAND ----------
+
 

--- a/data/pinecone_vector_creation.py
+++ b/data/pinecone_vector_creation.py
@@ -107,3 +107,15 @@ for i in range(0, len(pdf), BATCH_SIZE):
 
     index.upsert(vectors=vectors)
 
+
+# COMMAND ----------
+
+query = "Angel Reese"
+
+query_embedding = embed_batch([query])[0]
+
+results = index.query(
+    vector=query_embedding,
+    top_k=5,
+    include_metadata=True
+)


### PR DESCRIPTION
This pull request introduces two new Databricks notebooks for processing and vectorizing WNBA news article data. The first notebook (`data/data_prep.py`) handles data import, cleaning, chunking, and saving to Delta tables. The second notebook (`data/pinecone_vector_creation.py`) sets up Pinecone and OpenAI integrations to generate embeddings for the chunked data and upload them to a Pinecone index for semantic search.

**Data Preparation and Cleaning:**

* Imports JSON news article data, creates a Spark DataFrame, and saves it as a Delta table (`news_articles_bronze`).
* Cleans the data by dropping rows with empty text, removing newlines, and saving the cleaned data as a new Delta table (`news_articles_clean`).
* Splits the cleaned text into chunks, explodes them into separate rows, assigns unique chunk IDs, and saves the result as another Delta table (`news_articles_chunked`).

**Vector Embedding and Pinecone Integration:**

* Reads the chunked data, sets up Pinecone and OpenAI API keys using Databricks secrets, and initializes a Pinecone index if it doesn't exist.
* Batches the chunked text, generates embeddings using OpenAI's `text-embedding-ada-002` model, and uploads the vectors (with metadata) to the Pinecone index.
* Includes sample code for querying the Pinecone index with an embedded search query and retrieving top results with metadata.